### PR TITLE
fix: turn off termination policy for db & tofu fmt

### DIFF
--- a/argocd.tf
+++ b/argocd.tf
@@ -6,32 +6,32 @@ provider "helm" {
 }
 
 locals {
-  repo_url = "https://github.com/MCCE2024/INENPT-G8"
-  repo_path = "gitops-base"
-  app_name = "gitops-base"
+  repo_url      = "https://github.com/MCCE2024/INENPT-G8"
+  repo_path     = "gitops-base"
+  app_name      = "gitops-base"
   app_namespace = "argocd"
 }
 
 # Install ArgoCD via the official Helm chart
 resource "helm_release" "argo_cd" {
-  name             = "argocd"                                  # Name of the Helm release
-  repository       = "https://argoproj.github.io/argo-helm"    # ArgoCD Helm chart repo
-  chart            = "argo-cd"                                 # Chart name
-  version          = "7.8.22"                                  # Specific version of the chart
-  timeout          = 1200                                      # Max wait time (seconds)
-  create_namespace = true                                      # Create the 'argocd' namespace if missing
-  namespace        = "argocd"                                  # Target namespace for ArgoCD
-  lint             = true                                      # Lint chart before applying
-  wait             = true                                      # Wait until deployment is complete
+  name             = "argocd"                               # Name of the Helm release
+  repository       = "https://argoproj.github.io/argo-helm" # ArgoCD Helm chart repo
+  chart            = "argo-cd"                              # Chart name
+  version          = "7.8.22"                               # Specific version of the chart
+  timeout          = 1200                                   # Max wait time (seconds)
+  create_namespace = true                                   # Create the 'argocd' namespace if missing
+  namespace        = "argocd"                               # Target namespace for ArgoCD
+  lint             = true                                   # Lint chart before applying
+  wait             = true                                   # Wait until deployment is complete
 
   # Customize ArgoCD service to expose a LoadBalancer on ports 80 and 443
   values = [
-      templatefile("app-values.yaml", {
-        repo_url      = local.repo_url
-        repo_path     = local.repo_path
-        app_name      = local.app_name
-        app_namespace = local.app_namespace
-      })
+    templatefile("app-values.yaml", {
+      repo_url      = local.repo_url
+      repo_path     = local.repo_path
+      app_name      = local.app_name
+      app_namespace = local.app_namespace
+    })
   ]
 
   # Ensure kubeconfig exists before this release is deployed

--- a/db.tf
+++ b/db.tf
@@ -1,26 +1,27 @@
 resource "exoscale_dbaas" "pg" {
   # Defines a PostgreSQL database service on Exoscale
-  name = "postgres-db"
-  type = "pg"
-  plan = "hobbyist-2"
-  zone = var.zone
- 
+  name                   = "postgres-db"
+  type                   = "pg"
+  plan                   = "hobbyist-2"
+  zone                   = var.zone
+  termination_protection = false # Enable termination protection to prevent accidental deletion
+
   pg {
     # PostgreSQL-specific configuration
-    version         = "15"                  # PostgreSQL version to use
-    backup_schedule = "04:00"               # Daily backup time (UTC)
-    ip_filter       = ["0.0.0.0/0"]         # Allow connections from any IP address (not recommended for production)
-    pg_settings     = jsonencode({ timezone = "Europe/Berlin" })  # Set timezone setting for PostgreSQL
+    version         = "15"                                       # PostgreSQL version to use
+    backup_schedule = "04:00"                                    # Daily backup time (UTC)
+    ip_filter       = ["0.0.0.0/0"]                              # Allow connections from any IP address (not recommended for production)
+    pg_settings     = jsonencode({ timezone = "Europe/Berlin" }) # Set timezone setting for PostgreSQL
   }
 }
- 
+
 resource "exoscale_dbaas_pg_database" "appdb" {
   # Creates a PostgreSQL database named "appdb" in the above service
   database_name = "appdb"
   service       = exoscale_dbaas.pg.name
   zone          = exoscale_dbaas.pg.zone
 }
- 
+
 resource "exoscale_dbaas_pg_user" "appuser" {
   # Creates a PostgreSQL user named "appuser" with access to the service
   username = "appuser"

--- a/sks.tf
+++ b/sks.tf
@@ -5,10 +5,10 @@ data "exoscale_security_group" "default" {
 
 # Create a new SKS cluster in Exoscale
 resource "exoscale_sks_cluster" "sks_cluster" {
-  zone          = var.zone                 # Region/zone for the cluster
-  name          = var.cluster_name         # Name of the cluster
-  version       = var.kubernetes_version   # Kubernetes version
-  service_level = var.service_level        # Cluster tier (e.g., starter)
+  zone          = var.zone               # Region/zone for the cluster
+  name          = var.cluster_name       # Name of the cluster
+  version       = var.kubernetes_version # Kubernetes version
+  service_level = var.service_level      # Cluster tier (e.g., starter)
 }
 
 resource "exoscale_sks_kubeconfig" "sks_kubeconfig" {
@@ -33,24 +33,24 @@ resource "exoscale_security_group" "sks_security_group" {
 
 # Allow TCP traffic for Kubelet between nodes
 resource "exoscale_security_group_rule" "kubelet" {
-  security_group_id        = exoscale_security_group.sks_security_group.id
-  description              = "Kubelet"
-  type                     = "INGRESS"
-  protocol                 = "TCP"
-  start_port               = 10250
-  end_port                 = 10250
-  user_security_group_id   = exoscale_security_group.sks_security_group.id
+  security_group_id      = exoscale_security_group.sks_security_group.id
+  description            = "Kubelet"
+  type                   = "INGRESS"
+  protocol               = "TCP"
+  start_port             = 10250
+  end_port               = 10250
+  user_security_group_id = exoscale_security_group.sks_security_group.id
 }
 
 # Allow Calico VXLAN UDP traffic between nodes for pod networking
 resource "exoscale_security_group_rule" "calico_vxlan" {
-  security_group_id        = exoscale_security_group.sks_security_group.id
-  description              = "VXLAN (Calico)"
-  type                     = "INGRESS"
-  protocol                 = "UDP"
-  start_port               = 4789
-  end_port                 = 4789
-  user_security_group_id   = exoscale_security_group.sks_security_group.id
+  security_group_id      = exoscale_security_group.sks_security_group.id
+  description            = "VXLAN (Calico)"
+  type                   = "INGRESS"
+  protocol               = "UDP"
+  start_port             = 4789
+  end_port               = 4789
+  user_security_group_id = exoscale_security_group.sks_security_group.id
 }
 
 # Public access to NodePort services (TCP)
@@ -61,7 +61,7 @@ resource "exoscale_security_group_rule" "nodeport_tcp" {
   protocol          = "TCP"
   start_port        = 30000
   end_port          = 32767
-  cidr              = "0.0.0.0/0"  # Public access
+  cidr              = "0.0.0.0/0" # Public access
 }
 
 # Public access to NodePort services (UDP)
@@ -72,16 +72,16 @@ resource "exoscale_security_group_rule" "nodeport_udp" {
   protocol          = "UDP"
   start_port        = 30000
   end_port          = 32767
-  cidr              = "0.0.0.0/0"  # Public access
+  cidr              = "0.0.0.0/0" # Public access
 }
 
 # Create a nodepool for the SKS cluster
 resource "exoscale_sks_nodepool" "sks_nodepool" {
-  cluster_id          = exoscale_sks_cluster.sks_cluster.id
-  zone                = exoscale_sks_cluster.sks_cluster.zone
-  name                = var.nodepool_name
-  instance_type       = var.instance_type
-  size                = var.nodepool_size
+  cluster_id    = exoscale_sks_cluster.sks_cluster.id
+  zone          = exoscale_sks_cluster.sks_cluster.zone
+  name          = var.nodepool_name
+  instance_type = var.instance_type
+  size          = var.nodepool_size
 
   # Attach both the default and custom security groups
   security_group_ids = [

--- a/versions.tf
+++ b/versions.tf
@@ -1,20 +1,20 @@
 # Define where to store the state file (S3 remote backend)
 terraform {
   backend "s3" {
-    bucket = "inenpt-state"         # S3 bucket to store the .tfstate file
-    key    = "terraform.tfstate"    # Path to state file within bucket
-    region = "us-east-1"            # AWS region for S3
+    bucket = "inenpt-state"      # S3 bucket to store the .tfstate file
+    key    = "terraform.tfstate" # Path to state file within bucket
+    region = "us-east-1"         # AWS region for S3
   }
 
   # Declare required providers and versions
   required_providers {
     exoscale = {
-      source = "exoscale/exoscale"   # Exoscale cloud provider
+      source  = "exoscale/exoscale" # Exoscale cloud provider
       version = "0.64.1"
     }
     helm = {
-      source  = "hashicorp/helm"     # Helm chart provider
-      version = "2.12.1"             # Specific version
+      source  = "hashicorp/helm" # Helm chart provider
+      version = "2.12.1"         # Specific version
     }
   }
 }


### PR DESCRIPTION
The policy prevented the tofu destroy action since the db wasn't allowed to be deleted when the policy was turned on.